### PR TITLE
Update installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ git clone https://github.com/ton-community/tact-template
 TACT is distributed via NPM, to install tact into your project, you need:
 
 ```bash
-yarn install ton-tact
+yarn add ton-tact
 ```
 
 TACT doesn't have environment dependencies and have everything built in. TACT's stdlib also distributed together with a compiler.


### PR DESCRIPTION
`yarn install` has been replaced by `yarn add` in the recent versions.